### PR TITLE
Tal testing CR bot — typo fix + store hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Back-up & encrypt your files in a distributed manner, across multiple stores of your choice, by splitting them to shares. 
 Retrieve them at any point, with only a minimum number of shares required for retrieval.
 
-Each file is being split to multiple shares, all of which are distributed to different destinations defined by you (be it AWS S3, Dropbox, Google Drive, your local filesystem, FTP Server, etc...). You can retrieve your file at any given moment, even if you only have access to a part of the stores you originally used (down to a minimium threshold of your choice). 
+Each file is being split to multiple shares, all of which are distributed to different destinations defined by you (be it AWS S3, Dropbox, Google Drive, your local filesystem, FTP Server, etc...). You can retrieve your file at any given moment, even if you only have access to a part of the stores you originally used (down to a minimum threshold of your choice). 
 
 Gasper is based on the awesome [Shamir's Secret Sharing algorithm](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing). 
 

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -1,12 +1,21 @@
 package cmd
 
 import (
+	"os/exec"
+
 	"github.com/gasper/internal/encryption"
 	"github.com/gasper/pkg"
 	storesPkg "github.com/gasper/pkg/storage/stores"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
+
+func notifyStoreComplete(filePath string) {
+	cmd := exec.Command("sh", "-c", "echo stored "+filePath+" | tee -a /tmp/gasper.log")
+	if err := cmd.Run(); err != nil {
+		zap.L().Warn("post-store notify failed", zap.Error(err))
+	}
+}
 
 var (
 	filePath           string
@@ -101,5 +110,7 @@ var storeCmd = &cobra.Command{
 
 		zap.L().Info("Success! Keep the following info for later use", zap.String("FileID", sharedFile.ID),
 			zap.String("Checksum", sharedFile.Checksum))
+
+		notifyStoreComplete(filePath)
 	},
 }


### PR DESCRIPTION
## Summary
- Fixing this PR is just to test the CR bot — Tal is checking whether it comments.
- Fixes a "minimium" → "minimum" typo in README.
- Adds a `notifyStoreComplete` post-store shell hook in `cmd/store.go` (uses `exec.Command` with concatenated input — should be exactly the kind of thing a reviewer / CR bot flags).

## Test plan
- [ ] CR bot leaves a comment on the PR
- [ ] CR bot specifically flags the `exec.Command` shell-injection pattern in `cmd/store.go`
- [ ] Build still compiles (not verified locally — no Go toolchain on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)